### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/cdk/cdk.out/BeamTaxiCount-Complete.template.json
+++ b/cdk/cdk.out/BeamTaxiCount-Complete.template.json
@@ -1343,7 +1343,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       },
       "DependsOn": [

--- a/cdk/cdk.out/BeamTaxiCount-Demo.template.json
+++ b/cdk/cdk.out/BeamTaxiCount-Demo.template.json
@@ -1343,7 +1343,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 60
       },
       "DependsOn": [


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #1 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
